### PR TITLE
Remove "UI" from window title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="cis">
   <head>
-    <title>Crops in Silico UI</title>
+    <title>Crops in Silico</title>
     <base href="/">
     <link rel=icon href="asset/favicon.ico">
     


### PR DESCRIPTION
Changes the window title from `Crops in Silico UI` to `Crops in Silico`