### PR TITLE
Fix 'Copy to Clipboard' button on Generate Manifest modal

### DIFF
--- a/app/main/modals/generateYaml/generateYaml.controller.js
+++ b/app/main/modals/generateYaml/generateYaml.controller.js
@@ -23,8 +23,7 @@ angular
       alert('Sorry, copy to clipboard is not supported');
       return;
     }
-    let formatted = $scope.reformat($scope.legacy);
-    clipboard.copyText(formatted);
+    clipboard.copyText(results);
   };
 
   $scope.close = function() {


### PR DESCRIPTION
Fixes stale reference to the `$scope.reformat()` function, which has been deleted