### PR TITLE
Basic support for IE11

### DIFF
--- a/app/cis.module.js
+++ b/app/cis.module.js
@@ -33,7 +33,7 @@ angular.module('cis', [ 'ngMessages', 'ngResource', 'ngRoute', 'ngCookies', 'ang
 .constant('ApiUri', '/api/v1')
 .constant('AuthCookieName', 'girderToken')
 .constant('AuthHeaderName', 'Girder-Token')
-.factory('CisApi', [ 'ApiUri', 'ApiServer', (ApiUri, ApiServer) => {
+.factory('CisApi', [ 'ApiUri', 'ApiServer', function(ApiUri, ApiServer) {
   return new ApiServer(ApiUri);
 }])
 

--- a/app/editor.directive.js
+++ b/app/editor.directive.js
@@ -137,7 +137,7 @@ angular.module('cis')
             var onResize = function() {
                 scope.height = window.innerHeight;
                 scope.width = window.innerWidth;
-                $log.debug(`Resize event detected 2: ${scope.width}x${scope.height}... reloading!`);
+                $log.debug("Resize event detected 2: " + scope.width + "x" + scope.height + "... reloading!");
                 
                 ReactDOM.unmountComponentAtNode(element);
                 render();

--- a/app/main/main.controller.js
+++ b/app/main/main.controller.js
@@ -138,7 +138,7 @@ angular.module('cis')
         keyboard: false,      // Force the user to explicitly click "Close"
         backdrop: 'static',   // Force the user to explicitly click "Close"
         resolve: {
-          selectedItem: () => angular.copy(newValue)
+          selectedItem: function() { return angular.copy(newValue) }
         }
       });
       
@@ -405,7 +405,7 @@ angular.module('cis')
       // Import our previous state, if one was found
       if (loadedNodes && loadedNodes.length) {
         // Import all nodes from localStorage into TheGraph
-        angular.forEach(loadedNodes, node => {
+        angular.forEach(loadedNodes, function(node) {
           var exists = _.find($scope.graph.nodes, [ 'id', node.id ]);
           if (!exists) {
             $scope.graph.addNode(node.id, node.component, node.metadata);
@@ -416,7 +416,7 @@ angular.module('cis')
         
         // Then, import all edges
         let loadedEdges = edges || angular.fromJson($window.localStorage.getItem(LocalStorageKeys.edges));
-        loadedEdges && angular.forEach(loadedEdges, edge => { $scope.graph.addEdge(edge.from.node, edge.from.port, edge.to.node, edge.to.port, edge.metadata); });
+        loadedEdges && angular.forEach(loadedEdges, function(edge) { $scope.graph.addEdge(edge.from.node, edge.from.port, edge.to.node, edge.to.port, edge.metadata); });
         
         // Store our previously saved state
         $scope.lastSavedNodes = angular.copy($scope.graph.nodes);
@@ -489,8 +489,8 @@ angular.module('cis')
       keyboard: false,      // Force the user to explicitly click "Close"
       backdrop: 'static',   // Force the user to explicitly click "Close"
       resolve: {
-        results: () => params.results,
-        title: () => params.title || "View Details"
+        results: function() { return params.results },
+        title: function() { return params.title || "View Details" }
       }
     });
   };


### PR DESCRIPTION
Fixes https://github.com/cropsinsilico/Cis_Repository/issues/163

* Removed use of ES6 "arrow functions" which are [not supported in IE11](https://caniuse.com/#feat=arrow-functions)
* Removed use of ES6 template literals in strings are [not supported in IE11](https://caniuse.com/#feat=template-literals)