### PR TITLE
Fix issue with Edit Spec adding a "creatorId" field into outputted YAML 

### DIFF
--- a/app/main/main.controller.js
+++ b/app/main/main.controller.js
@@ -558,6 +558,10 @@ angular.module('cis')
       // PUT result to /spec
       $log.debug("Submitting updated model:", updatedModel);
       
+      // FIXME: Why does this content include a creatorId?
+      // This additional property causes cisrun to choke.
+      delete updatedModel.creatorId;
+      
       // Find our target spec id and update the spec content
       var specs = SpecService.query();
       specs.$promise.then(function() {

--- a/app/main/main.controller.js
+++ b/app/main/main.controller.js
@@ -558,8 +558,8 @@ angular.module('cis')
       // PUT result to /spec
       $log.debug("Submitting updated model:", updatedModel);
       
-      // FIXME: Why does this content include a creatorId?
       // This additional property causes cisrun to choke.
+      // See main.controller.js -> $scope.requerySpecs() above for definition
       delete updatedModel.creatorId;
       
       // Find our target spec id and update the spec content


### PR DESCRIPTION
Fixes https://github.com/cropsinsilico/Cis_Repository/issues/166

* Removed stray creatorId after editSpec
  * Q: ~~Side note: where does this even come from??~~
  * A: It turns out that I needed to inject this field into the content to determine whether or not the user was allowed to edit each a spec